### PR TITLE
Filter out world document types before splitting content into unlabel…

### DIFF
--- a/python/clean_content.py
+++ b/python/clean_content.py
@@ -127,6 +127,14 @@ logger.debug('Text extracted from title looks like: %s', content['title'][0:10])
 logger.info('Concatenating title, description, and text.')
 content['combined_text'] = content['title'] + ' ' + content['description'] + ' ' + content['body']
 
+# stripout out-of-scope World items
+
+logger.info('content shape before removing doctypes related to world %s', content.shape)
+content = content[content.document_type != 'worldwide_organisation']
+content = content[content.document_type != 'placeholder_world_location_news_page']
+content = content[content.document_type != 'travel_advice']
+logger.info('content shape after removing doctypes related to world %s', content.shape)
+
 # Identify and select untagged content items
 
 logger.info('Separating untagged content')


### PR DESCRIPTION
Additional lines to remove the World document types from all content before splitting into labelled/unlabelled. So shouldn't bias the training data...