### PR TITLE
Fix the Rummager search generator

### DIFF
--- a/python/data_extraction/rummager.py
+++ b/python/data_extraction/rummager.py
@@ -10,7 +10,7 @@ class Rummager():
         self.base_url = base_url
 
     def search_generator(self, args, page_size=100):
-        for index in count(page_size):
+        for index in count(0, page_size):
             search_params = merge(args, {"start": index, "count": page_size})
             results = self.__search(search_params).get('results', [])
             for result in results:

--- a/python/test/data_extraction/test_rummager.py
+++ b/python/test/data_extraction/test_rummager.py
@@ -3,17 +3,17 @@ from data_extraction import rummager
 import responses
 
 
-def stub_rummager(json):
-    responses.add(responses.GET, "http://example.com/search.json",
-                  json=json, status=200)
+def stub_rummager(json, start, count):
+    responses.add(responses.GET, "http://example.com/search.json?start={start}&count={count}".format(start=start, count=count),
+                  json=json, status=200, match_querystring=True)
 
 
 class TestRummager(unittest.TestCase):
 
     @responses.activate
     def test_search_generator(self):
-        stub_rummager({'results': [{'title': 't1'}, {'title': 't2'}]})
-        stub_rummager({'results': [{'title': 't3'}]})
+        stub_rummager({'results': [{'title': 't1'}, {'title': 't2'}]}, 0, 2)
+        stub_rummager({'results': [{'title': 't3'}]}, 2, 2)
 
         search_results = [{'title': 't1'}, {'title': 't2'}, {'title': 't3'}]
         results = rummager.Rummager("http://example.com").search_generator({}, 2)


### PR DESCRIPTION
The paging of the Rummager search client contained an error which
has now been fixed.

This caused the exporting of all content to write too many documents.