### PR TITLE
Enhancements in content/taxon export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ content : $(DATADIR)/clean_content.csv
 labelled : $(DATADIR)/labelled.csv
 new: $(DATADIR)/new_content.csv
 
+data/content.json:
+	cd python && python3 -u -c "from data_extraction.export_data import export_content; export_content(output='../data/content.json')"
+
+data/taxons.json:
+	cd python && python3 -u -c "from data_extraction.export_data import export_taxons; export_taxons(output='../data/taxons.json')"
 
 $(DATADIR)/clean_taxons.csv : python/clean_taxons.py $(DATADIR)/raw_taxons.json
 	python3 python/clean_taxons.py
@@ -30,7 +35,7 @@ $(DATADIR)/labelled.csv : python/create_labelled.py $(DATADIR)/clean_content.csv
     $(DATADIR)/clean_taxons.csv
 	python3 python/create_labelled.py
 
-$(DATADIR)/document_type_group_lookup.json : 
+$(DATADIR)/document_type_group_lookup.json :
 	aws s3 cp $(S3BUCKET)/document_type_group_lookup.json $(DATADIR)/document_type_group_lookup.json
 
 $(DATADIR)/raw_taxons.json :
@@ -58,7 +63,9 @@ clean :
 	    $(DATADIR)/untagged_content.csv $(DATADIR)/empty_taxons.csv \
 	    $(DATADIR)/labelled.csv $(DATADIR)/filtered.csv $(DATADIR)/old_taxons.csv \
 	    $(DATADIR)/labelled_level1.csv $(DATADIR)/labelled_level2.csv \
-	    $(DATADIR)/empty_taxons_not_world.csv $(DATADIR)/new_content.csv
+	    $(DATADIR)/empty_taxons_not_world.csv $(DATADIR)/new_content.csv \
+	    data/taxons.json data/content.json
+
 
 clean_all : clean
 	-rm -f $(DATADIR)/document_type_group_lookup.json \

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -1,7 +1,10 @@
 from data_extraction import content_export
 from data_extraction import taxonomy_query, plek
 import json
+import sys
 import functools
+from multiprocessing import Pool
+
 
 with open('config/data_export_fields.json') as json_data_file:
     configuration = json.load(json_data_file)
@@ -27,7 +30,8 @@ def taxonomy():
 
 
 def content():
-    content_generator = map(get_content, content_links_generator)
+    pool = Pool(10)
+    content_generator = pool.imap(get_content, content_links_generator, 50)
     return filter(lambda link: link, content_generator)
 
 

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -35,12 +35,13 @@ def content():
     return filter(lambda link: link, content_generator)
 
 
-def export_content():
-    __write_json("/tmp/content.json", content())
+
+def export_content(output="data/content.json"):
+    __write_json(output, content())
 
 
-def export_taxons():
-    __write_json("/tmp/taxons.json", taxonomy())
+def export_taxons(output="data/taxons.json"):
+    __write_json(output, taxonomy())
 
 
 # PRIVATE

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -54,5 +54,6 @@ def __write_json(filename, generator):
             file.write(",\n")
             file.write(json.dumps(taxon))
             if index % 1000 is 0:
-                print("Documents exported: %s" % index)
+                print("Documents exported: %s" % index, file=sys.stderr)
         file.write("]\n")
+        print("Documents exported: %s" % index, file=sys.stderr)


### PR DESCRIPTION
- Use multithreading to speed up content retrieval when exporting content.
- Allow caller to specify filenames for content/taxon export.
- Send content export status updates to Stderr to disable buffering
in Jenkins.

Trello: 
- https://trello.com/c/xmHpofxM/35-rewrite-the-data-extraction-part-of-the-pipeline-in-python
- https://trello.com/c/yZw1SCiF/86-setup-a-job-on-the-deploy-jenkins-to-extract-data