### PR TITLE
Export untagged content items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,19 @@ taxons : $(DATADIR)/clean_taxons.csv.gz
 content : $(DATADIR)/clean_content.csv.gz
 labelled : $(DATADIR)/labelled.csv.gz
 new: $(DATADIR)/new_content.csv.gz
+export_all: data/export_filtered_content.json.gz data/export_untagged_content.json.gz data/taxons.json
 
-data/content.json:
-	cd python && python3 -u -c "from data_extraction.export_data import export_content; export_content(output='../data/content.json')"
+data/content.json.gz:
+	cd python && python3 -u -c "from data_extraction.export_data import export_content; export_content(output_filename='../data/content.json.gz')"
 
-data/taxons.json:
-	cd python && python3 -u -c "from data_extraction.export_data import export_taxons; export_taxons(output='../data/taxons.json')"
+data/export_filtered_content.json.gz : data/content.json.gz
+	cd python && python3 -u -c "from data_extraction.export_data import export_filtered_content; export_filtered_content(input_filename='../data/content.json.gz', output_filename='../data/filtered_content.json.gz')"
+
+data/export_untagged_content.json.gz : data/content.json.gz
+	cd python && python3 -u -c "from data_extraction.export_data import export_untagged_content; export_untagged_content(input_filename='../data/content.json.gz', output_filename='../data/untagged_content.json.gz')"
+
+data/taxons.json.gz:
+	cd python && python3 -u -c "from data_extraction.export_data import export_taxons; export_taxons(output_filename='../data/taxons.json.gz')"
 
 $(DATADIR)/clean_taxons.csv.gz : python/clean_taxons.py $(DATADIR)/raw_taxons.json
 	python3 python/clean_taxons.py
@@ -64,7 +71,7 @@ clean :
 	    $(DATADIR)/labelled.csv.gz  $(DATADIR)/filtered.csv.gz  $(DATADIR)/old_taxons.csv.gz  \
 	    $(DATADIR)/labelled_level1.csv.gz  $(DATADIR)/labelled_level2.csv.gz  \
 	    $(DATADIR)/empty_taxons_not_world.csv.gz  $(DATADIR)/new_content.csv.gz \
-	    data/taxons.json data/content.json
+	    data/taxons.json data/content.json.gz data/export_untagged_content.json.gz data/export_filtered_content.json.gz
 
 clean_all : clean
 	-rm -f $(DATADIR)/document_type_group_lookup.json \

--- a/python/config/data_export_fields.json
+++ b/python/config/data_export_fields.json
@@ -10,6 +10,17 @@
     "description",
     "details"
   ],
+  "untagged_content_fields": [
+    "title",
+    "description",
+    "document_type",
+    "first_published_at",
+    "email_document_supertype",
+    "navigation_document_supertype",
+    "publishing_app",
+    "updated_at",
+    "withdrawn_notice"
+  ],
   "taxon_fields": [
     "title",
     "content_id"

--- a/python/data_extraction/content_export.py
+++ b/python/data_extraction/content_export.py
@@ -8,17 +8,17 @@ def content_links_generator(page_size=1000,
                             additional_search_fields = {},
                             rummager_url=plek.find('rummager'),
                             blacklist_document_types=[]):
-    search_hash = merge({'reject_content_store_document_type': blacklist_document_types,
+    search_dict = merge({'reject_content_store_document_type': blacklist_document_types,
                          'fields': ['link']},
                         additional_search_fields)
-    search_results = rummager.Rummager(rummager_url).search_generator(search_hash, page_size=page_size)
+    search_results = rummager.Rummager(rummager_url).search_generator(search_dict, page_size=page_size)
     return map(lambda h: h.get('link'), search_results)
 
 
-def content_hash_slicer(content_hash, base_fields=[], taxon_fields=[], ppo_fields=[]):
-    result = slice(content_hash, base_fields)
-    taxons = dig(content_hash, 'links', 'taxons')
-    ppo = dig(content_hash, 'links', 'primary_publishing_organisation')
+def content_dict_slicer(content_dict, base_fields=[], taxon_fields=[], ppo_fields=[]):
+    result = slice(content_dict, base_fields)
+    taxons = dig(content_dict, 'links', 'taxons')
+    ppo = dig(content_dict, 'links', 'primary_publishing_organisation')
 
     if taxons:
         result['taxons'] = [slice(taxon, taxon_fields) for taxon in taxons]
@@ -28,11 +28,11 @@ def content_hash_slicer(content_hash, base_fields=[], taxon_fields=[], ppo_field
     return result
 
 
-def untagged_hash_slicer(content_hash, base_fields=[], ppo_fields=[]):
-    result = slice(content_hash, base_fields)
+def untagged_dict_slicer(content_dict, base_fields=[], ppo_fields=[]):
+    result = slice(content_dict, base_fields)
 
-    logo = dig(content_hash, 'links', 'organisations', 0, 'details', 'logo', 'formatted-title')
-    ppo = dig(content_hash, 'links', 'primary_publishing_organisation')
+    logo = dig(content_dict, 'links', 'organisations', 0, 'details', 'logo', 'formatted-title')
+    ppo = dig(content_dict, 'links', 'primary_publishing_organisation')
 
     if logo:
         result['logo'] = logo
@@ -44,24 +44,24 @@ def untagged_hash_slicer(content_hash, base_fields=[], ppo_fields=[]):
 
 def get_content(base_path,
                 content_store_url=plek.find('draft-content-store')):
-    content_hash = __get_content_hash(base_path, content_store_url)
+    content_dict = __get_content_dict(base_path, content_store_url)
 
     # Skip this if we don't get back the content we expect, e.g. if
     # the Content Store has redirected the request
-    if content_hash.get('base_path') != base_path:
+    if content_dict.get('base_path') != base_path:
         return {}
 
     # Skip anything without a content_id
-    if 'content_id' not in content_hash:
+    if 'content_id' not in content_dict:
         return {}
 
-    return content_hash
+    return content_dict
 
 
 # PRIVATE
 
 
-def __get_content_hash(path, content_store_url):
+def __get_content_dict(path, content_store_url):
 
     url = "{content_store_url}/content{path}".format(content_store_url=content_store_url, path=path)
     response = requests.get(url)

--- a/python/data_extraction/content_export.py
+++ b/python/data_extraction/content_export.py
@@ -9,10 +9,20 @@ def content_links_generator(page_size=1000, rummager_url=plek.find('rummager'), 
     return map(lambda h: h.get('link'), search_results)
 
 
+def content_hash_slicer(content_hash, base_fields=[], taxon_fields=[], ppo_fields=[]):
+    result = slice(content_hash, base_fields)
+    taxons = dig(content_hash, 'links', 'taxons')
+    ppo = dig(content_hash, 'links', 'primary_publishing_organisation')
+
+    if taxons:
+        result['taxons'] = [slice(taxon, taxon_fields) for taxon in taxons]
+    if ppo:
+        result['primary_publishing_organisation'] = slice(ppo[0], ppo_fields)
+
+    return result
+
+
 def get_content(base_path,
-                base_fields=[],
-                taxon_fields=[],
-                ppo_fields=[],
                 content_store_url=plek.find('draft-content-store')):
     content_hash = __get_content_hash(base_path, content_store_url)
 
@@ -25,20 +35,14 @@ def get_content(base_path,
     if 'content_id' not in content_hash:
         return {}
 
-    base = slice(content_hash, base_fields)
-    taxons = dig(content_hash, 'links', 'taxons')
-    ppo = dig(content_hash, 'links', 'primary_publishing_organisation')
-
-    if taxons:
-        base['taxons'] = [slice(taxon, taxon_fields) for taxon in taxons]
-    if ppo:
-        base['primary_publishing_organisation'] = slice(ppo[0], ppo_fields)
-
-    return base
+    return content_hash
 
 
 # PRIVATE
+
+
 def __get_content_hash(path, content_store_url):
+
     url = "{content_store_url}/content{path}".format(content_store_url=content_store_url, path=path)
     response = requests.get(url)
     if response.status_code == 200:

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -42,7 +42,7 @@ def export_content(output_filename="data/content.json.gz"):
 
 
 def export_filtered_content(input_filename="data/content.json.gz", output_filename="data/filtered_content.json.gz"):
-    slicer = functools.partial(content_export.content_hash_slicer,
+    slicer = functools.partial(content_export.content_dict_slicer,
                                base_fields=configuration['base_fields'],
                                taxon_fields=configuration['taxon_fields'],
                                ppo_fields=configuration['ppo_fields'])
@@ -53,16 +53,16 @@ def export_filtered_content(input_filename="data/content.json.gz", output_filena
 
 
 def export_untagged_content(input_filename="data/content.json.gz", output_filename="data/untagged_content.json.gz"):
-    def __filter_tagged(hash_in):
-        return dig(hash_in, 'links', 'taxons') is None
+    def __filter_tagged(dict_in):
+        return dig(dict_in, 'links', 'taxons') is None
 
-    untagged_hash_slicer = functools.partial(content_export.untagged_hash_slicer,
+    untagged_dict_slicer = functools.partial(content_export.untagged_dict_slicer,
                                              base_fields=configuration['untagged_content_fields'],
                                              ppo_fields=configuration['ppo_fields'])
 
     __transform_content(input_filename=input_filename,
                         output_filename=output_filename,
-                        transform_function=lambda iterator: map(untagged_hash_slicer, filter(__filter_tagged, iterator)))
+                        transform_function=lambda iterator: map(untagged_dict_slicer, filter(__filter_tagged, iterator)))
 
 
 def export_taxons(output_filename="data/taxons.json.gz"):

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -1,63 +1,78 @@
 from data_extraction import content_export
 from data_extraction import taxonomy_query, plek
-import json
-import sys
+from data_extraction import json_arrays
+from data_extraction.helpers import dig
 import functools
 from multiprocessing import Pool
+import gzip
+import json
+import os
 
 
-with open('config/data_export_fields.json') as json_data_file:
+config_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..', 'config', 'data_export_fields.json')
+
+with open(config_path) as json_data_file:
     configuration = json.load(json_data_file)
 
 
-content_links_generator = content_export.content_links_generator(
-    blacklist_document_types=configuration['blacklist_document_types']
-)
+def __transform_content(input_filename="data/content.json.gz",
+                        output_filename="data/filtered_content.json.gz",
+                        transform_function=lambda x: x):
+    with gzip.open(input_filename, mode='rt') as input_file:
+        with gzip.open(output_filename, mode='wt') as output_file:
+            content_generator = json_arrays.read_json(input_file)
+            json_arrays.write_json(output_file, transform_function(content_generator))
 
 
-slicer = functools.partial(content_export.content_hash_slicer,
-                           base_fields=configuration['base_fields'],
-                           taxon_fields=configuration['taxon_fields'],
-                           ppo_fields=configuration['ppo_fields'])
+def export_content(output_filename="data/content.json.gz"):
+    def __complete_content():
+        get_content = functools.partial(content_export.get_content,
+                                        content_store_url=plek.find('draft-content-store'))
+
+        content_links_generator = content_export.content_links_generator(
+            blacklist_document_types=configuration['blacklist_document_types']
+        )
+
+        pool = Pool(10)
+        return pool.imap(get_content, content_links_generator)
+
+    with gzip.open(output_filename, 'wt') as output_file:
+        json_arrays.write_json(output_file,
+                               filter(lambda link: link, __complete_content()))
 
 
-get_content = functools.partial(content_export.get_content,
-                                content_store_url=plek.find('draft-content-store'))
+def export_filtered_content(input_filename="data/content.json.gz", output_filename="data/filtered_content.json.gz"):
+    slicer = functools.partial(content_export.content_hash_slicer,
+                               base_fields=configuration['base_fields'],
+                               taxon_fields=configuration['taxon_fields'],
+                               ppo_fields=configuration['ppo_fields'])
+
+    __transform_content(input_filename=input_filename,
+                        output_filename=output_filename,
+                        transform_function=lambda iterator: map(slicer, iterator))
 
 
-def taxonomy():
-    query = taxonomy_query.TaxonomyQuery()
-    level_one_taxons = query.level_one_taxons()
-    children = [taxon
-                for level_one_taxon in level_one_taxons
-                for taxon in query.child_taxons(level_one_taxon['base_path'])]
-    return iter(level_one_taxons + children)
+def export_untagged_content(input_filename="data/content.json.gz", output_filename="data/untagged_content.json.gz"):
+    def __filter_tagged(hash_in):
+        return dig(hash_in, 'links', 'taxons') is None
+
+    untagged_hash_slicer = functools.partial(content_export.untagged_hash_slicer,
+                                             base_fields=configuration['untagged_content_fields'],
+                                             ppo_fields=configuration['ppo_fields'])
+
+    __transform_content(input_filename=input_filename,
+                        output_filename=output_filename,
+                        transform_function=lambda iterator: map(untagged_hash_slicer, filter(__filter_tagged, iterator)))
 
 
-def content():
-    pool = Pool(10)
-    content_generator = pool.imap(get_content, content_links_generator)
-    return filter(lambda link: link, map(slicer, content_generator))
+def export_taxons(output_filename="data/taxons.json.gz"):
+    def __taxonomy():
+        query = taxonomy_query.TaxonomyQuery()
+        level_one_taxons = query.level_one_taxons()
+        children = [taxon
+                    for level_one_taxon in level_one_taxons
+                    for taxon in query.child_taxons(level_one_taxon['base_path'])]
+        return iter(level_one_taxons + children)
 
-
-def export_content(output="data/content.json"):
-    __write_json(output, content())
-
-
-def export_taxons(output="data/taxons.json"):
-    __write_json(output, taxonomy())
-
-# PRIVATE
-
-
-def __write_json(filename, generator):
-    with open(filename, 'w') as file:
-        file.write("[ ")
-        file.write(json.dumps(next(generator)))
-        for index, taxon in enumerate(generator):
-            file.write(",\n")
-            file.write(json.dumps(taxon))
-            if index % 1000 is 0:
-                print("Documents exported: %s" % index, file=sys.stderr)
-        file.write("]\n")
-        print("Documents exported: %s" % index, file=sys.stderr)
+    with gzip.open(output_filename, 'wt') as output_file:
+        json_arrays.write_json(output_file, __taxonomy())

--- a/python/data_extraction/helpers.py
+++ b/python/data_extraction/helpers.py
@@ -4,8 +4,13 @@ def slice(hash_in, key_list):
 
 def dig(hash_in, *key_list):
     (head, *tail) = key_list
-    value = hash_in.get(head)
-    if len(tail) == 0 or (value is None) or not isinstance(value, dict):
+    if isinstance(head, int) and isinstance(hash_in, list):
+        value = hash_in[head]
+    elif isinstance(head, str) and isinstance(hash_in, dict):
+        value = hash_in.get(head)
+    else:
+        return hash_in
+    if len(tail) == 0:
         return value
     else:
         return dig(value, *tail)

--- a/python/data_extraction/helpers.py
+++ b/python/data_extraction/helpers.py
@@ -1,20 +1,20 @@
-def slice(hash_in, key_list):
-    return {key: value for (key, value) in hash_in.items() if key in key_list}
+def slice(dict_in, key_list):
+    return {key: value for (key, value) in dict_in.items() if key in key_list}
 
 
-def dig(hash_in, *key_list):
+def dig(dict_in, *key_list):
     (head, *tail) = key_list
-    if isinstance(head, int) and isinstance(hash_in, list):
-        value = hash_in[head]
-    elif isinstance(head, str) and isinstance(hash_in, dict):
-        value = hash_in.get(head)
+    if isinstance(head, int) and isinstance(dict_in, list):
+        value = dict_in[head]
+    elif isinstance(head, str) and isinstance(dict_in, dict):
+        value = dict_in.get(head)
     else:
-        return hash_in
+        return dict_in
     if len(tail) == 0:
         return value
     else:
         return dig(value, *tail)
 
 
-def merge(hash_one, hash_two):
-    return dict(hash_one, **hash_two)
+def merge(dict_one, dict_two):
+    return dict(dict_one, **dict_two)

--- a/python/data_extraction/json_arrays.py
+++ b/python/data_extraction/json_arrays.py
@@ -1,0 +1,22 @@
+import json
+import sys
+
+
+def read_json(stream):
+    for line in stream:
+        json_line = line.strip('\n [],')
+        if json_line:
+            yield json.loads(json_line)
+
+
+def write_json(stream, generator):
+    stream.write("[ ")
+    stream.write(json.dumps(next(generator)))
+    index = 0
+    for index, taxon in enumerate(generator):
+        stream.write(",\n")
+        stream.write(json.dumps(taxon))
+        if index % 1000 is 0:
+            print("Documents exported: %s" % index, file=sys.stderr)
+    stream.write("]\n")
+    print("Documents exported: %s" % index, file=sys.stderr)

--- a/python/data_extraction/taxonomy_query.py
+++ b/python/data_extraction/taxonomy_query.py
@@ -10,33 +10,33 @@ class TaxonomyQuery():
         self.key_list = key_list
 
     def level_one_taxons(self):
-        taxons = dig(self.__get_content_hash('/'), "links", "level_one_taxons")
+        taxons = dig(self.__get_content_dict('/'), "links", "level_one_taxons")
         return [slice(taxon, self.key_list) for taxon in taxons]
 
     def child_taxons(self, base_path):
-        root_content_hash = self.__get_content_hash(base_path)
-        taxons = dig(root_content_hash, "links", "child_taxons") or []
-        return self.__recursive_child_taxons(taxons, root_content_hash['content_id'])
+        root_content_dict = self.__get_content_dict(base_path)
+        taxons = dig(root_content_dict, "links", "child_taxons") or []
+        return self.__recursive_child_taxons(taxons, root_content_dict['content_id'])
 
     # PRIVATE
 
-    def __build_child_hash(self, taxon, parent_content_id):
-        sliced_hash = slice(taxon, key_list=self.key_list)
-        sliced_hash['parent_content_id'] = parent_content_id
-        return sliced_hash
+    def __build_child_dict(self, taxon, parent_content_id):
+        sliced_dict = slice(taxon, key_list=self.key_list)
+        sliced_dict['parent_content_id'] = parent_content_id
+        return sliced_dict
 
     @staticmethod
     def __child_taxons(taxon):
         return dig(taxon, 'links', 'child_taxons') or []
 
     def __recursive_child_taxons(self, taxons, parent_content_id):
-        current_taxons = [self.__build_child_hash(taxon, parent_content_id) for taxon in taxons]
+        current_taxons = [self.__build_child_dict(taxon, parent_content_id) for taxon in taxons]
         children = [descendents
                     for taxon in taxons
                     for descendents in self.__recursive_child_taxons(self.__child_taxons(taxon), taxon['content_id'])
                     ]
         return current_taxons + children
 
-    def __get_content_hash(self, path):
+    def __get_content_dict(self, path):
         url = "{base}/content{path}".format(base=self.content_store_url, path=path)
         return requests.get(url).json()

--- a/python/test/data_extraction/content_store_helpers.py
+++ b/python/test/data_extraction/content_store_helpers.py
@@ -1,0 +1,110 @@
+import responses, uuid
+from data_extraction import plek
+
+
+def content_store_has_item(path, json):
+    responses.add(responses.GET, plek.find("draft-content-store") + "/content" + path,
+                  json=json, status=200)
+
+
+level_one_taxons = {
+    "links": {
+        "level_one_taxons":
+            [
+                {"base_path": "/taxons/root_taxon",
+                 "content_id": "rrrr"}
+            ]
+        }
+}
+
+multi_level_child_taxons = {
+    "base_path": "/taxons/root_taxon",
+    "content_id": "rrrr",
+    "links": {
+        "child_taxons": [
+            {
+                "base_path": "/root_taxon/taxon_a",
+                "content_id": "aaaa",
+                "links": {
+                    "child_taxons": [
+                        {
+                            "base_path": "/root_taxon/taxon_1",
+                            "content_id": "aaaa_1111",
+                            "links": {}
+                        },
+                        {
+                            "base_path": "/root_taxon/taxon_2",
+                            "content_id": "aaaa_2222",
+                            "links": {}
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+
+def single_level_child_taxons(root, child_1, child_2):
+    return {
+        "base_path": "/taxons/#{root}",
+        "content_id": root,
+        "links": {
+            "child_taxons": [
+                {
+                    "base_path": "/taxons/%s" % child_1,
+                    "content_id": child_1,
+                    "links": {}
+                },
+                {
+                    "base_path": "/taxons/%s" % child_2,
+                    "content_id": child_2,
+                    "links": {}
+                }
+            ]
+        }
+    }
+
+content_with_taxons = {
+    "base_path": "/base_path",
+    "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+    "links": {
+        "taxons": [{"content_id": "237b2e72-c465-42fe-9293-8b6af21713c0"},
+                   {"content_id": "8da62d85-47c0-42df-94c4-eaaeac329671"}]
+    }
+}
+
+content_with_ppo = {
+    "base_path": "/base_path",
+    "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+    "links": {
+        "primary_publishing_organisation": [
+            {"title": "title1"}
+        ]
+    },
+}
+
+content_without_taxons = {
+    "base_path": "/base_path",
+    "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
+    "links": {
+    }
+}
+
+content_links = {
+    'results': [{'link': '/first/path'}, {'link': '/second/path'}]
+}
+
+content_first = {
+    "base_path": '/first/path',
+    "content_id": str(uuid.uuid4()),
+    "links": {
+    }
+}
+
+content_second = {
+    "base_path": '/second/path',
+    "content_id": str(uuid.uuid4()),
+    "links": {
+    }
+}

--- a/python/test/data_extraction/test_content_export.py
+++ b/python/test/data_extraction/test_content_export.py
@@ -62,23 +62,24 @@ class GetContent(unittest.TestCase):
         responses.add(responses.GET, "http://example.com/content/base_path", json=content_no_taxon())
         expected = {"base_path": "/base_path", "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f"}
         response = content_export.get_content('/base_path',
-                                             base_fields = ["base_path", "content_id"],
-                                             content_store_url="http://example.com")
-        self.assertDictEqual(response, expected)
+                                              content_store_url="http://example.com")
+        self.assertEquals(expected.get('base_path'), response.get('base_path'))
+        self.assertEquals(expected.get('content_id'), response.get('content_id'))
 
     @responses.activate
     def test_taxons(self):
         responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_taxons())
         expected = [{"content_id": "237b2e72-c465-42fe-9293-8b6af21713c0"},
                     {"content_id": "8da62d85-47c0-42df-94c4-eaaeac329671"}]
-        response = content_export.get_content('/base_path', content_store_url="http://example.com",
-                                              taxon_fields=["content_id"])
-        self.assertListEqual(response.get('taxons'), expected)
+        response = content_export.get_content('/base_path',
+                                              content_store_url="http://example.com")
+
+        self.assertListEqual(response.get('links').get('taxons'), expected)
 
     @responses.activate
     def test_primary_publishing_organisations(self):
         responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_ppo())
         expected = {"title": "title1"}
-        response = content_export.get_content('/base_path', content_store_url="http://example.com",
-                                              ppo_fields=["title"])
-        self.assertDictEqual(response.get('primary_publishing_organisation'), expected)
+        response = content_export.get_content('/base_path',
+                                              content_store_url="http://example.com")
+        self.assertDictEqual(response.get('links').get('primary_publishing_organisation')[0], expected)

--- a/python/test/data_extraction/test_content_export.py
+++ b/python/test/data_extraction/test_content_export.py
@@ -1,56 +1,19 @@
 import unittest
-from data_extraction import content_export
 import responses
+from data_extraction import content_export
+from test.data_extraction.content_store_helpers import *
 
 
-def content_with_taxons():
-    return {
-        "base_path": "/base_path",
-        "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
-        "links": {
-            "taxons": [{"content_id": "237b2e72-c465-42fe-9293-8b6af21713c0"},
-                       {"content_id": "8da62d85-47c0-42df-94c4-eaaeac329671"}]
-        }
-    }
-
-
-def content_with_ppo():
-    return {
-        "base_path": "/base_path",
-        "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
-        "links": {
-            "primary_publishing_organisation": [
-                {"title": "title1"}
-            ]
-        },
-    }
-
-
-def content_no_taxon():
-    return {
-        "base_path": "/base_path",
-        "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f",
-        "links": {
-        }
-    }
-
-
-def content_links():
-    return {
-        'results': [{'link': '/first/path'}, {'link': '/second/path'}]
-    }
-
-
-class ContentLinksGenerator(unittest.TestCase):
+class TestContentLinksGenerator(unittest.TestCase):
 
     @responses.activate
     def test_content_links_generator(self):
-        responses.add(responses.GET, "http://example.com/search.json", json=content_links())
+        responses.add(responses.GET, "http://example.com/search.json", json=content_links)
         response = content_export.content_links_generator(rummager_url="http://example.com")
         self.assertListEqual(list(response), ['/first/path', '/second/path'])
 
 
-class GetContent(unittest.TestCase):
+class TestGetContent(unittest.TestCase):
 
     @responses.activate
     def test_empty_hash(self):
@@ -59,7 +22,7 @@ class GetContent(unittest.TestCase):
 
     @responses.activate
     def test_simple_content(self):
-        responses.add(responses.GET, "http://example.com/content/base_path", json=content_no_taxon())
+        responses.add(responses.GET, "http://example.com/content/base_path", json=content_without_taxons)
         expected = {"base_path": "/base_path", "content_id": "d282d35a-2bd2-4e14-a7a6-a04e6b10520f"}
         response = content_export.get_content('/base_path',
                                               content_store_url="http://example.com")
@@ -68,7 +31,7 @@ class GetContent(unittest.TestCase):
 
     @responses.activate
     def test_taxons(self):
-        responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_taxons())
+        responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_taxons)
         expected = [{"content_id": "237b2e72-c465-42fe-9293-8b6af21713c0"},
                     {"content_id": "8da62d85-47c0-42df-94c4-eaaeac329671"}]
         response = content_export.get_content('/base_path',
@@ -78,7 +41,7 @@ class GetContent(unittest.TestCase):
 
     @responses.activate
     def test_primary_publishing_organisations(self):
-        responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_ppo())
+        responses.add(responses.GET, "http://example.com/content/base_path", json=content_with_ppo)
         expected = {"title": "title1"}
         response = content_export.get_content('/base_path',
                                               content_store_url="http://example.com")

--- a/python/test/data_extraction/test_content_export.py
+++ b/python/test/data_extraction/test_content_export.py
@@ -16,7 +16,7 @@ class TestContentLinksGenerator(unittest.TestCase):
 class TestGetContent(unittest.TestCase):
 
     @responses.activate
-    def test_empty_hash(self):
+    def test_empty_dict(self):
         responses.add(responses.GET, "http://example.com/content/base_path", status=404)
         self.assertDictEqual(content_export.get_content('/base_path', content_store_url="http://example.com"), {})
 

--- a/python/test/data_extraction/test_export_data.py
+++ b/python/test/data_extraction/test_export_data.py
@@ -1,0 +1,73 @@
+import unittest
+import unittest.mock
+from data_extraction import export_data
+from test.data_extraction.content_store_helpers import *
+import responses
+import json
+import io
+
+
+class MockIO:
+    def __init__(self):
+        self.buffer = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, t, v, tr):
+        return self
+
+    def write(self, b):
+        self.buffer = self.buffer + b
+
+
+class TestExportData(unittest.TestCase):
+    @responses.activate
+    def test_level_export_taxons(self):
+        content_store_has_item('/taxons/root_taxon', multi_level_child_taxons)
+        content_store_has_item("/", json=level_one_taxons)
+
+        output = MockIO()
+        with unittest.mock.patch('gzip.open', return_value=output):
+            export_data.export_taxons()
+            expected = [{"base_path": "/taxons/root_taxon", "content_id": "rrrr"},
+                        {"parent_content_id": "rrrr", "base_path": "/root_taxon/taxon_a", "content_id": "aaaa"},
+                        {"parent_content_id": "aaaa", "base_path": "/root_taxon/taxon_1", "content_id": "aaaa_1111"},
+                        {"parent_content_id": "aaaa", "base_path": "/root_taxon/taxon_2", "content_id": "aaaa_2222"}]
+            self.assertEqual(expected, json.loads(output.buffer))
+
+    def return_input_or_output(self, input_io, output_io):
+        return lambda *_, **ka: input_io if ka['mode'] == 'rt' else output_io
+
+    @responses.activate
+    def test_export_content(self):
+        output = MockIO()
+        responses.add(responses.GET, "http://rummager.dev.gov.uk/search.json", json=content_links)
+        content_store_has_item(content_first['base_path'], json=content_first)
+        content_store_has_item(content_second['base_path'], json=content_second)
+        with unittest.mock.patch('gzip.open', return_value=output):
+            export_data.export_content()
+            expected = [content_first, content_second]
+            self.assertEqual(expected, json.loads(output.buffer))
+
+    def test_export_filtered_content(self):
+        input_string = "[" + json.dumps(content_with_taxons) + ",\n" + json.dumps(content_without_taxons) + "\n]"
+        output = MockIO()
+        with unittest.mock.patch('gzip.open',
+                                 side_effect=self.return_input_or_output(io.StringIO(input_string), output)):
+            export_data.export_filtered_content()
+            expected = [{"taxons": content_with_taxons['links']['taxons'],
+                         "base_path": content_with_taxons['base_path'],
+                         "content_id": content_with_taxons["content_id"]},
+                        {"base_path": content_without_taxons['base_path'],
+                         "content_id": content_without_taxons["content_id"]}]
+            self.assertEqual(expected, json.loads(output.buffer))
+
+    def export_untagged_content(self):
+        output = MockIO()
+        input_string = "[" + json.dumps(content_with_taxons) + ",\n" + json.dumps(content_without_taxons) + "\n]"
+
+        with unittest.mock.patch('gzip.open',
+                                 side_effect=self.return_input_or_output(io.StringIO(input_string), output)):
+            export_data.export_filtered_content()
+            self.assertListEqual([content_without_taxons], json.loads(output.buffer))

--- a/python/test/data_extraction/test_helpers.py
+++ b/python/test/data_extraction/test_helpers.py
@@ -12,5 +12,17 @@ class TestHelpers(unittest.TestCase):
     def test_dig(self):
         self.assertEqual(dig({"a": {"b": {"c": "d"}}}, "a", "b", "c"), "d")
 
+    def test_dig_none(self):
+        self.assertEqual(dig({"a": {"b": {"c": "d"}}}, "a", "b", "q"), None)
+
+    def test_dig_none2(self):
+        self.assertEqual(dig({"a": {"b": {"c": "d"}}}, "a", "q", "b"), None)
+
+    def test_dig_array(self):
+        self.assertEqual(dig({"a": {"b": [1, 2, 3]}}, "a", "b", 1), 2)
+
+    def test_dig_deep_array(self):
+        self.assertEqual(dig({"a": {"b": [1, {'q': 'z'}, 3]}}, "a", "b", 1, 'q'), 'z')
+
     def test_merge(self):
         self.assertEqual(merge({"a": 1}, {"b": 2}), {"a": 1, "b": 2})

--- a/python/test/data_extraction/test_json_arrays.py
+++ b/python/test/data_extraction/test_json_arrays.py
@@ -1,0 +1,22 @@
+import unittest
+from data_extraction import json_arrays
+import io
+
+
+class TestHelpers(unittest.TestCase):
+    def test_read_json(self):
+        test_string = """  [ {"a":"2", "b": [1,2]}, 
+                          {"a":1, "b":2}] """
+
+        generator = json_arrays.read_json(io.StringIO(test_string))
+        self.assertDictEqual(next(generator), {'a': '2', 'b': [1, 2]})
+        self.assertDictEqual(next(generator), {'a': 1, 'b': 2})
+
+
+    def test_write_json(self):
+        output = io.StringIO()
+        json_arrays.write_json(output, iter([{"a": 1}, {"b": 2}]))
+        expected_output = """[ {"a": 1},
+{"b": 2}]
+"""
+        self.assertEquals(output.getvalue(), expected_output)

--- a/python/test/data_extraction/test_taxonomy_query.py
+++ b/python/test/data_extraction/test_taxonomy_query.py
@@ -1,6 +1,6 @@
 import unittest
 from data_extraction import taxonomy_query
-from data_extraction import plek
+from test.data_extraction.content_store_helpers import *
 import responses
 
 
@@ -14,7 +14,7 @@ class TestTaxonomyQuery(unittest.TestCase):
 
     @responses.activate
     def test_child_taxons_empty_array(self):
-        content_store_has_item('/taxons/root_taxon', no_taxons())
+        content_store_has_item('/taxons/root_taxon', content_without_taxons)
         self.assertListEqual(taxonomy_query.TaxonomyQuery().child_taxons('/taxons/root_taxon'), [])
 
     @responses.activate
@@ -27,71 +27,9 @@ class TestTaxonomyQuery(unittest.TestCase):
 
     @responses.activate
     def test_child_taxons_multiple_levels(self):
-        content_store_has_item('/taxons/root_taxon', multi_level_child_taxons())
+        content_store_has_item('/taxons/root_taxon', multi_level_child_taxons)
         taxons = taxonomy_query.TaxonomyQuery().child_taxons('/taxons/root_taxon')
         expected = [{'content_id': 'aaaa', 'base_path': '/root_taxon/taxon_a', 'parent_content_id': 'rrrr'},
                     {'content_id': 'aaaa_1111', 'base_path': '/root_taxon/taxon_1', 'parent_content_id': 'aaaa'},
                     {'content_id': 'aaaa_2222', 'base_path': '/root_taxon/taxon_2', 'parent_content_id': 'aaaa'}]
         self.assertCountEqual(taxons, expected)
-
-
-def content_store_has_item(path, json):
-    responses.add(responses.GET, plek.find("draft-content-store") + "/content" + path,
-                  json=json, status=200)
-
-
-def multi_level_child_taxons():
-    return {
-        "base_path": "/taxons/root_taxon",
-        "content_id": "rrrr",
-        "links": {
-            "child_taxons": [
-                {
-                    "base_path": "/root_taxon/taxon_a",
-                    "content_id": "aaaa",
-                    "links": {
-                        "child_taxons": [
-                            {
-                                "base_path": "/root_taxon/taxon_1",
-                                "content_id": "aaaa_1111",
-                                "links": {}
-                            },
-                            {
-                                "base_path": "/root_taxon/taxon_2",
-                                "content_id": "aaaa_2222",
-                                "links": {}
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-
-
-def single_level_child_taxons(root, child_1, child_2):
-    return {
-        "base_path": "/taxons/#{root}",
-        "content_id": root,
-        "links": {
-            "child_taxons": [
-                {
-                    "base_path": "/taxons/%s" % child_1,
-                    "content_id": child_1,
-                    "links": {}
-                },
-                {
-                    "base_path": "/taxons/%s" % child_2,
-                    "content_id": child_2,
-                    "links": {}
-                }
-            ]
-        }
-    }
-
-
-def no_taxons():
-    return {
-        "base_path": "/",
-        "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
-    }


### PR DESCRIPTION
Saves the complete in-scope dump from the content store
Adds functions to export data from all untagged items to a file.

Trello: 
- https://trello.com/c/2C792Ubu/53-identify-in-scope-content-not-tagged-to-any-taxon
- https://trello.com/c/sIgcxfgU/130-changes-in-data-extraction-pipeline