### PR TITLE
Export content remove duplicates

### DIFF
--- a/python/data_extraction/content_export.py
+++ b/python/data_extraction/content_export.py
@@ -46,14 +46,17 @@ def get_content(base_path,
                 content_store_url=plek.find('draft-content-store')):
     content_dict = __get_content_dict(base_path, content_store_url)
 
+    if not content_dict:
+        return False
+
     # Skip this if we don't get back the content we expect, e.g. if
     # the Content Store has redirected the request
     if content_dict.get('base_path') != base_path:
-        return {}
+        return False
 
     # Skip anything without a content_id
     if 'content_id' not in content_dict:
-        return {}
+        return False
 
     return content_dict
 
@@ -68,4 +71,4 @@ def __get_content_dict(path, content_store_url):
     if response.status_code == 200:
         return requests.get(url).json()
     else:
-        return {}
+        return False

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -26,19 +26,25 @@ def __transform_content(input_filename="data/content.json.gz",
 
 def export_content(output_filename="data/content.json.gz"):
     def __complete_content():
-        get_content = functools.partial(content_export.get_content,
-                                        content_store_url=plek.find('draft-content-store'))
+        get_content = functools.partial(
+            content_export.get_content,
+            content_store_url=plek.find('draft-content-store')
+        )
 
         content_links_generator = content_export.content_links_generator(
-            blacklist_document_types=configuration['blacklist_document_types']
+            blacklist_document_types=configuration[
+                'blacklist_document_types'
+            ]
         )
 
         pool = Pool(10)
         return pool.imap(get_content, content_links_generator)
 
     with gzip.open(output_filename, 'wt') as output_file:
-        json_arrays.write_json(output_file,
-                               filter(lambda link: link, __complete_content()))
+        json_arrays.write_json(
+            output_file,
+            filter(lambda link: link, __complete_content())
+        )
 
 
 def export_filtered_content(input_filename="data/content.json.gz", output_filename="data/filtered_content.json.gz"):

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -31,14 +31,22 @@ def export_content(output_filename="data/content.json.gz"):
             content_store_url=plek.find('draft-content-store')
         )
 
-        content_links_generator = content_export.content_links_generator(
-            blacklist_document_types=configuration[
-                'blacklist_document_types'
-            ]
+        content_links_list = list(
+            content_export.content_links_generator(
+                blacklist_document_types=configuration[
+                    'blacklist_document_types'
+                ]
+            )
         )
 
+        content_links_set = set(content_links_list)
+        duplicate_links = len(content_links_list) - len(content_links_set)
+
+        if duplicate_links > 0:
+            print("{} duplicate links from Rummager".format(duplicate_links))
+
         pool = Pool(10)
-        return pool.imap(get_content, content_links_generator)
+        return pool.imap(get_content, content_links_set)
 
     with gzip.open(output_filename, 'wt') as output_file:
         json_arrays.write_json(

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,3 +15,4 @@ pytest==3.3.2
 requests==2.18.4
 responses==0.8.1
 statsd==3.2.2
+progressbar2==3.35.2

--- a/python/test/data_extraction/test_content_export.py
+++ b/python/test/data_extraction/test_content_export.py
@@ -16,9 +16,9 @@ class TestContentLinksGenerator(unittest.TestCase):
 class TestGetContent(unittest.TestCase):
 
     @responses.activate
-    def test_empty_dict(self):
+    def test_404_response(self):
         responses.add(responses.GET, "http://example.com/content/base_path", status=404)
-        self.assertDictEqual(content_export.get_content('/base_path', content_store_url="http://example.com"), {})
+        self.assertFalse(content_export.get_content('/base_path', content_store_url="http://example.com"))
 
     @responses.activate
     def test_simple_content(self):

--- a/python/test/data_extraction/test_export_data.py
+++ b/python/test/data_extraction/test_export_data.py
@@ -38,7 +38,7 @@ class TestExportData(unittest.TestCase):
         with unittest.mock.patch('gzip.open', return_value=output):
             export_data.export_content()
             expected = [content_first, content_second]
-            self.assertEqual(expected, json.loads(output.buffer))
+            self.assertCountEqual(expected, json.loads(output.buffer))
 
     def test_export_filtered_content(self):
         input_string = "[" + json.dumps(content_with_taxons) + ",\n" + json.dumps(content_without_taxons) + "\n]"


### PR DESCRIPTION
These changes should make certain that the content export does not contain duplicates.
 
The progress bar looks something like this:

```
→ cd python && python3 -u -c "from data_extraction.export_data import export_content; export_content(output_filename='../data/content.json.gz')"
| 202365 Elapsed Time: 0:03:19                                                               
30356 duplicate links from Rummager
  0% (608 of 172010) |                                  | Elapsed Time: 0:00:26 ETA:  2:04:02
```