### PR TITLE
Use Plek in the test_export_content test

### DIFF
--- a/python/test/data_extraction/test_export_data.py
+++ b/python/test/data_extraction/test_export_data.py
@@ -42,7 +42,11 @@ class TestExportData(unittest.TestCase):
     @responses.activate
     def test_export_content(self):
         output = MockIO()
-        responses.add(responses.GET, "http://rummager.dev.gov.uk/search.json", json=content_links)
+        responses.add(
+            responses.GET,
+            "{}/search.json".format(plek.find("rummager")),
+            json=content_links
+        )
         content_store_has_item(content_first['base_path'], json=content_first)
         content_store_has_item(content_second['base_path'], json=content_second)
         with unittest.mock.patch('gzip.open', return_value=output):


### PR DESCRIPTION
As the Plek configuration isn't controlled by the test setup, this
test can break if the Plek configuration changes. So use Plek in the
test itself to make this work independently of the configuration.

This makes local development easier, as you can set the Plek
configuration, and not break the tests.