### PR TITLE
Fix in statsd prefix

### DIFF
--- a/python/lib/services.py
+++ b/python/lib/services.py
@@ -1,3 +1,3 @@
 from statsd import StatsClient
 
-statsd = StatsClient(prefix="stats.gauges.govuk.topic-taxonomy")
+statsd = StatsClient(prefix="govuk.topic-taxonomy")


### PR DESCRIPTION
The python library automatically prefixes with stats.gauges, so this prevents
statsd to log to stats.gauges.stats.gauges.govuk.topic-taxonomy