### PR TITLE
Use live content store instead draft

### DIFF
--- a/python/data_extraction/content_export.py
+++ b/python/data_extraction/content_export.py
@@ -43,7 +43,7 @@ def untagged_dict_slicer(content_dict, base_fields=[], ppo_fields=[]):
 
 
 def get_content(base_path,
-                content_store_url=plek.find('draft-content-store')):
+                content_store_url=plek.find('content-store')):
     content_dict = __get_content_dict(base_path, content_store_url)
 
     if not content_dict:

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -3,7 +3,6 @@ from data_extraction import content_export
 from data_extraction import taxonomy_query
 from lib import plek
 from lib.helpers import dig
-import yaml
 import functools
 import progressbar
 from multiprocessing import Pool
@@ -53,7 +52,7 @@ def __transform_content(input_filename="data/content.json.gz",
 def __get_all_content():
     get_content = functools.partial(
         content_export.get_content,
-        content_store_url=plek.find('draft-content-store')
+        content_store_url=plek.find('content-store')
     )
 
     blacklisted_document_types = data.document_types_excluded_from_the_topic_taxonomy()

--- a/python/data_extraction/taxonomy_query.py
+++ b/python/data_extraction/taxonomy_query.py
@@ -5,7 +5,7 @@ from lib.helpers import slice, dig
 
 class TaxonomyQuery():
     def __init__(self, key_list=("content_id", "base_path", "title"),
-                 content_store_url=plek.find("draft-content-store")):
+                 content_store_url=plek.find("content-store")):
         self.content_store_url = content_store_url
         self.key_list = key_list
 

--- a/python/test/data_extraction/content_store_helpers.py
+++ b/python/test/data_extraction/content_store_helpers.py
@@ -3,7 +3,7 @@ from lib import plek
 
 
 def content_store_has_item(path, json):
-    responses.add(responses.GET, plek.find("draft-content-store") + "/content" + path,
+    responses.add(responses.GET, plek.find("content-store") + "/content" + path,
                   json=json, status=200)
 
 


### PR DESCRIPTION
We published our taxonomy so we can use the live content store to retrieve content.

Trello: https://trello.com/c/5blGA4a3/197-investigate-why-out-of-scope-document-types-are-still-included