### PR TITLE
Remove blacklisted content

### DIFF
--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -49,19 +49,18 @@ def __transform_content(input_filename="data/content.json.gz",
             __stream_json(output_file, transform_function(content_generator))
 
 
-def __get_all_content():
+def __get_all_content(blacklist_document_types=[]):
     get_content = functools.partial(
         content_export.get_content,
         content_store_url=plek.find('content-store')
     )
 
-    blacklisted_document_types = data.document_types_excluded_from_the_topic_taxonomy()
     progress_bar = progressbar.ProgressBar()
 
     content_links_list = list(
         progress_bar(
             content_export.content_links_generator(
-                blacklist_document_types=blacklisted_document_types
+                blacklist_document_types=blacklist_document_types
             )
         )
     )
@@ -77,6 +76,7 @@ def __get_all_content():
 
 
 def export_content(output_filename="data/content.json.gz"):
+    blacklist_document_types = data.document_types_excluded_from_the_topic_taxonomy()
     seen_content_ids = set()
     duplicate_content_ids = []
 
@@ -95,7 +95,7 @@ def export_content(output_filename="data/content.json.gz"):
         seen_content_ids.add(content_id)
         return True
 
-    content_iterator, count = __get_all_content()
+    content_iterator, count = __get_all_content(blacklist_document_types=blacklist_document_types)
     content = filter(filter_content, content_iterator)
 
     progress_bar = progressbar.ProgressBar(max_value=count)

--- a/python/data_extraction/export_data.py
+++ b/python/data_extraction/export_data.py
@@ -79,6 +79,7 @@ def export_content(output_filename="data/content.json.gz"):
     blacklist_document_types = data.document_types_excluded_from_the_topic_taxonomy()
     seen_content_ids = set()
     duplicate_content_ids = []
+    blacklisted_content = []
 
     def filter_content(content):
         # This can happen a few ways, for example, if the request to
@@ -90,6 +91,10 @@ def export_content(output_filename="data/content.json.gz"):
 
         if content_id in seen_content_ids:
             duplicate_content_ids.append(content_id)
+            return False
+
+        if content.get('document_type') in blacklist_document_types:
+            blacklisted_content.append(content)
             return False
 
         seen_content_ids.add(content_id)
@@ -107,6 +112,10 @@ def export_content(output_filename="data/content.json.gz"):
     print("Seen {} duplicate content ids".format(
         duplicate_content_ids_count
     ))
+
+    print("Blacklisted content: ")
+    for bc in blacklisted_content:
+        print("content_id: %s : document_type: %s" % (bc['content_id'], bc['document_type']))
 
 
 def export_filtered_content(input_filename="data/content.json.gz", output_filename="data/filtered_content.json.gz"):

--- a/python/test/data_extraction/content_store_helpers.py
+++ b/python/test/data_extraction/content_store_helpers.py
@@ -99,6 +99,7 @@ content_links = {
 content_first = {
     "base_path": '/first/path',
     "content_id": str(uuid.uuid4()),
+    "document_type": "document",
     "links": {
     }
 }
@@ -106,6 +107,7 @@ content_first = {
 content_second = {
     "base_path": '/second/path',
     "content_id": str(uuid.uuid4()),
+    "document_type": "document",
     "links": {
     }
 }


### PR DESCRIPTION
Rummager does not seem to remove all blacklisted content, so an
additional check is added to the filter function to remove and
report any content that has been missed.

Trello: https://trello.com/c/5blGA4a3/197-investigate-why-out-of-scope-document-types-are-still-included