### PR TITLE
Filter new content based on bulk-taggable 

### DIFF
--- a/python/notebooks/filter_untagged_data.ipynb
+++ b/python/notebooks/filter_untagged_data.ipynb
@@ -1,0 +1,600 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import re\n",
+    "import yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATADIR = os.getenv('DATADIR')\n",
+    "DATADIR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Read in data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_DIR = '../../../govuk-taxonomy-supervised-learning/'\n",
+    "DATADIR = '../../../govuk-taxonomy-supervised-learning/data'\n",
+    "DATADIR_NEW = os.path.join(DATADIR, '2018-03-12')\n",
+    "DATADIR_NEW"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_content = pd.read_csv(\n",
+    "    os.path.join(DATADIR_NEW, 'new_content.csv.gz'),\n",
+    "    dtype=object,\n",
+    "    compression='gzip'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filters = pd.read_csv(\n",
+    "    os.path.join(DATADIR_NEW, 'untagged_content - 3. Filters.csv'),\n",
+    "    dtype=object\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapping_path = 'untagged_content - 2. Count of content for each publishing org.csv'\n",
+    "prim_pub_org_mapping = pd.read_csv(os.path.join(DATADIR_NEW,mapping_path),dtype=object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oos_doc_types_path = \"python/config/document_types_excluded_from_the_topic_taxonomy.yml\"\n",
+    "with open(os.path.join(BASE_DIR,oos_doc_types_path), 'r') as stream:\n",
+    "    oos_doc_types = yaml.load(stream)['document_types']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oos_doc_types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def strip_prim_org(x):\n",
+    "    return re.sub('\\\"|}',\"\",x.split(\"=>\")[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "filters.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bulktag_doc_type = filters['Bulk Taggable Document types to filter out from unlabelled data'].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bulktag_doc_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping.drop(prim_pub_org_mapping.index[0],inplace=True)\n",
+    "prim_pub_org_mapping.drop(\"COUNTA of primary_publishing_organisation\",axis=1,inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping.dropna(subset=['Bulk Tag to'],axis=0,inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping['Level'] = prim_pub_org_mapping['Level'].\\\n",
+    "                map(lambda x: x if not isinstance(x,float) else \"Level 1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping['primary_publishing_organisation'] = prim_pub_org_mapping['primary_publishing_organisation'].\\\n",
+    "                map(strip_prim_org)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping.reset_index(drop=True,inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filters['Bulktaggable Primary publishing organisations to filter from unlabelled data'] = \\\n",
+    "                filters['Bulktaggable Primary publishing organisations to filter from unlabelled data'].map(strip_prim_org)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_prim_org = prim_pub_org_mapping['primary_publishing_organisation'].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(list_prim_org)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load in predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labelled_level2 = pd.read_csv(\n",
+    "    os.path.join(DATADIR_NEW, 'labelled_level2.csv.gz'),\n",
+    "    dtype=object,\n",
+    "    compression='gzip'\n",
+    ")# Create World taxon in case any items not identified \n",
+    "# through doc type in clean_content are still present\n",
+    "labelled_level2.loc[labelled_level2['level1taxon'] == 'World', 'level2taxon'] = 'world_level1'\n",
+    "\n",
+    "# creating categorical variable for level2taxons from values\n",
+    "labelled_level2['level2taxon'] = labelled_level2['level2taxon'].astype('category')\n",
+    "\n",
+    "# Add 1 because of zero-indexing to get 1-number of level2taxons as numerical targets\n",
+    "labelled_level2['level2taxon_code'] = labelled_level2.level2taxon.astype('category').cat.codes + 1\n",
+    "\n",
+    "# create dictionary of taxon category code to string label for use in model evaluation\n",
+    "labels_index = dict(zip((labelled_level2['level2taxon_code']),\n",
+    "                        labelled_level2['level2taxon']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del labelled_level2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prediction_path = \"new_predictions_1726_1203_.csv.gz\"\n",
+    "new_pred = pd.read_csv(os.path.join(DATADIR_NEW, prediction_path), dtype=object, compression='gzip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_arrays = np.load(os.path.join(DATADIR_NEW, 'new_arrays.npz'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"PREDICTION DATAFRAME\",new_pred.shape[0],\"NEW ARRAY\",len(new_arrays['content_id']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if new_arrays['content_id'].shape[0] == new_pred.shape[0]:\n",
+    "    new_pred['content_id'] = new_arrays['content_id']\n",
+    "else:\n",
+    "    print(\"warning: true_train and content_id may not originate from same data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newprob_by_id = pd.melt(new_pred, \n",
+    "                        id_vars=['content_id'], var_name='taxon2', value_name='prob')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newprob_by_id.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newprob_by_id['prob'] = pd.to_numeric(newprob_by_id['prob'])\n",
+    "newprob_by_id['taxon2'] = pd.to_numeric(newprob_by_id['taxon2'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newprob_by_id['taxon2label'] = newprob_by_id['taxon2'].map(labels_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = newprob_by_id[newprob_by_id['prob'] > 0.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions_meta = pd.merge(\n",
+    "    left=predictions,\n",
+    "    right=new_content,\n",
+    "    on='content_id',\n",
+    "    how='left',\n",
+    "    indicator=True, \n",
+    "    validate='m:m'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions_meta.loc[predictions_meta['taxon2label']==\"Administrative justice reform\"]['primary_publishing_organisation'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions_meta.to_csv(os.path.join(DATADIR_NEW, 'predictions_meta.csv.gz'),compression='gzip',index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_filter_pred = predictions_meta.loc[predictions_meta['primary_publishing_organisation'].isin(list_prim_org)].copy(deep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_filter_pred.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping['Level'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lvl1_org_df = prim_pub_org_mapping.loc[prim_pub_org_mapping['Level']=='Level 1']\n",
+    "lvl2_org_df = prim_pub_org_mapping.loc[prim_pub_org_mapping['Level']=='Level 2']\n",
+    "lvl3_org_df = prim_pub_org_mapping.loc[prim_pub_org_mapping['Level']=='Level 3']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_org_mapping.loc[prim_pub_org_mapping['primary_publishing_organisation'] == \"HM Courts & Tribunals Service\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "org_taxon_2 = {}\n",
+    "for item in lvl2_org_df.itertuples():\n",
+    "    org_taxon_2 [item[1]] = item[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def lvl2mapping(x):\n",
+    "    if x in org_taxon_2:\n",
+    "        return org_taxon_2[x]\n",
+    "    else:\n",
+    "        return np.NaN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_filter_pred['org_mapped_taxon2label'] = prim_pub_filter_pred['primary_publishing_organisation'].\\\n",
+    "                                map(lvl2mapping)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_filter_pred.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not_same_taxon_org = prim_pub_filter_pred.loc[prim_pub_filter_pred['org_mapped_taxon2label']!=\\\n",
+    "                                prim_pub_filter_pred['taxon2label']].copy(deep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not_same_taxon_org.dropna(subset=['org_mapped_taxon2label'],axis=0, inplace = True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not_same_taxon_org[['base_path','title','combined_text','primary_publishing_organisation','taxon2label','org_mapped_taxon2label']].\\\n",
+    "                        to_csv(\"taxon_disagreement_level2.csv\",index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not_same_taxon_org.loc[not_same_taxon_org['document_type']==\"news_story\"]['base_path'].values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Filter by out of scope `document_type`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "oos_doc_type_filtered = new_content.loc[~new_content['document_type'].isin(oos_doc_types)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Filter by bulk-taggable `document_type`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bulk_doc_type = new_content.loc[~new_content['document_type'].isin(bulktag_doc_type)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Filter by `primary_publishing_organisation`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prim_pub_filtered = new_content.loc[~new_content['primary_publishing_organisation'].isin(list_prim_org)]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "taxon-sl",
+   "language": "python",
+   "name": "taxon-sl"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
(or out of scope) document types and primary publishing organisations.
May as well merge this in.