### PR TITLE
Use a specific pip version in the Jenkins script

### DIFF
--- a/bin/govuk_taxonomy_supervised_learning_jenkins_script
+++ b/bin/govuk_taxonomy_supervised_learning_jenkins_script
@@ -4,7 +4,7 @@ rm -rf ./venv
 virtualenv --python=python3 --no-site-packages ./venv
 export VIRTUAL_ENV="$PWD/venv"
 export PATH="$PWD/venv/bin:$PATH"
-pip3 install --upgrade pip
+pip3 install pip==9.0.3
 
 make pip_install
 


### PR DESCRIPTION
To avoid failures related to newer pip versions.