### PR TITLE
Track navigation types in contextual sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ labelled : $(DATADIR)/labelled.csv.gz
 new: $(DATADIR)/new_content.csv.gz
 export_all: data/export_filtered_content.json.gz data/export_untagged_content.json.gz data/taxons.json
 
+contextual_sidebar_metrics: data/content.json.gz
+	python3 -u -c "from measurement.contextual_sidebar_metrics import contextual_sidebar_metrics; contextual_sidebar_metrics()"
+
 measure_average_taxons: data/content.json.gz
 	cd python && python3 -u -c "from measurement.average_taxons import measure_average_taxons; measure_average_taxons(filename='../data/content.json.gz')"
 

--- a/bin/govuk_taxonomy_supervised_learning_jenkins_script
+++ b/bin/govuk_taxonomy_supervised_learning_jenkins_script
@@ -6,6 +6,8 @@ rm -rf ./venv
 virtualenv --python=python3 --no-site-packages ./venv
 export VIRTUAL_ENV="$PWD/venv"
 export PATH="$PWD/venv/bin:$PATH"
+export PYTHONPATH="python"
+
 pip3 install pip==9.0.3
 
 make pip_install

--- a/bin/govuk_taxonomy_supervised_learning_jenkins_script
+++ b/bin/govuk_taxonomy_supervised_learning_jenkins_script
@@ -14,3 +14,4 @@ make clean
 make data/taxons.json.gz
 make data/content.json.gz
 make measure_average_taxons
+make contextual_sidebar_metrics

--- a/python/data/__init__.py
+++ b/python/data/__init__.py
@@ -17,7 +17,7 @@ def document_types_excluded_from_the_topic_taxonomy():
 
 def items_from_content_file(datadir=None, filename="content.json.gz"):
     if datadir is None:
-        datadir = os.getenv("DATADIR")
+        datadir = os.getenv("DATADIR") or "data"
 
     full_filename = os.path.join(datadir, filename)
 

--- a/python/measurement/contextual_sidebar_metrics.py
+++ b/python/measurement/contextual_sidebar_metrics.py
@@ -1,0 +1,48 @@
+import gzip
+import ijson
+import progressbar
+from collections import defaultdict
+from lib.helpers import dig
+from lib import services
+from data_extraction.export_data import jenkins_compatible_progress_bar
+from data import items_from_content_file
+
+def contextual_sidebar_metrics():
+    progress_bar = jenkins_compatible_progress_bar()
+    content_items = items_from_content_file()
+
+    nav_type_count = defaultdict(int)
+
+    for content_item in progress_bar(content_items):
+        nav_type_count[navigation_type(content_item)] += 1
+
+    for nav_type, count in nav_type_count.items():
+        services.statsd.gauge('contextual_navigation.nav_type.' + nav_type, count)
+        print("{}: {}".format(nav_type, count))
+
+    related_navigation_count = sum(nav_type_count[type] for type in ('mainstream', 'curated', 'default'))
+    services.statsd.gauge('contextual_navigation.related_navigation_count', related_navigation_count)
+
+def navigation_type(content_item):
+    mainstream_tags = dig(content_item, 'links', 'mainstream_browse_pages') or []
+    curated_items = dig(content_item, 'links', 'ordered_related_items') or []
+
+    step_by_step = dig(content_item, 'links', 'part_of_step_navs') or []
+    if len(step_by_step) != 1:
+        step_by_step = None
+
+    live_taxons = any(
+        taxon.get('phase') == 'live'
+        for taxon in dig(content_item, 'links', 'taxons') or []
+    )
+
+    if step_by_step:
+        return 'step_by_step'
+    elif mainstream_tags:
+        return 'mainstream'
+    elif curated_items:
+        return 'curated'
+    elif live_taxons:
+        return 'taxon'
+    else:
+        return 'default'


### PR DESCRIPTION
Track the amount of times each navigation type is displayed in the contextual
sidebar. Only one navigation type can appear and there is a priority in what
is displayed if the piece of content has more than one navigation type associated.

Trello;
https://trello.com/c/fzL0r8Cs/158-ability-to-track-pages-using-the-new-taxonomy