### PR TITLE
WIP change dataprep to branch or exact

### DIFF
--- a/.env_aws
+++ b/.env_aws
@@ -2,7 +2,7 @@
 
 export DATADIR=/data/2018-07-10
 export DATAFILE=labelled_level2.csv.gz
-export SINCE_THRESHOLD=2015-08-14
+export SINCE_THRESHOLD=2015-01-01
 export EXPERIMENT_NAME=last_3_years.h5
 export METADATA_LIST=''document_type' 'primary_publishing_organisation''
 

--- a/python/branch_level_agnostic_dataprep.py
+++ b/python/branch_level_agnostic_dataprep.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+
+import logging.config
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+import yaml
+import json
+
+# warnings.filterwarnings(action='ignore', category=DataConversionWarning)
+
+
+from dataprep import *
+
+DATADIR = os.getenv('DATADIR')
+SINCE_THRESHOLD = os.getenv('SINCE_THRESHOLD')
+METADATA_LIST = os.getenv('METADATA_LIST').split()
+
+
+if __name__ == "__main__":
+
+    LOGGING_CONFIG = os.getenv('LOGGING_CONFIG')
+    logging.config.fileConfig(LOGGING_CONFIG)
+    logger = logging.getLogger('levelagnostic_dataprep')
+
+    logger.info('Loading data')
+    labelled = load_labelled(SINCE_THRESHOLD, level='agnostic', branch=True)
+
+    logger.info('Creating multilabel dataframe')
+    binary_multilabel = create_binary_multilabel(labelled)
+   
+    print(binary_multilabel.columns)
+
+    np.save(os.path.join(DATADIR, 'levelagnostic_taxon_codes.npy'), binary_multilabel.columns)
+    taxon_codes = binary_multilabel.columns
+    logging.info('Shape of binary_multilabel df: % {}'.format(binary_multilabel.shape))
+
+    # ***** RESAMPLING OF MINORITY TAXONS **************
+    # ****************************************************
+    # - Training data = 80%
+    # - Development data = 10%
+    # - Test data = 10%
+
+    size_before_resample = binary_multilabel.shape[0]
+   
+    size_train = int(0.8 * size_before_resample)  # train split
+    logging.info('Size of train set: %s', size_train)
+
+    size_dev = int(0.1 * size_before_resample)  # test split
+    logging.info('Size of dev/test sets: %s', size_dev)
+
+    logger.info('Upsample low support taxons')
+
+    balanced_df, upsample_size = upsample_low_support_taxons(binary_multilabel, size_train, n_samples=50)
+
+    logger.info("Shape of balanced_df: {}".format(balanced_df.shape))
+    
+    size_train += upsample_size
+
+    logger.info("New size of training set: {}".format(size_train))
+
+    logger.info('Vectorizing metadata')
+
+    meta = create_meta(balanced_df.index.get_level_values('content_id'), labelled)
+
+    # **** TOKENIZE TEXT ********************
+    # ************************************
+
+    # Load tokenizers, fitted on both labelled and unlabelled data from file
+    # created in clean_content.py
+
+    logger.info('Tokenizing combined_text')
+
+    combined_text_sequences_padded = create_padded_combined_text_sequences(
+        balanced_df.index.get_level_values('combined_text')
+    )
+
+    # prepare title and description matrices,
+    # which are one-hot encoded for the 10,000 most common words
+    # to be fed in after the flatten layer (through fully connected layers)
+
+    logging.info('One-hot encoding title sequences')
+
+    title_onehot = create_one_hot_matrix_for_column(
+        tokenizing.load_tokenizer_from_file(
+            os.path.join(DATADIR, "title_tokenizer.json")
+        ),
+        balanced_df.index.get_level_values('title'),
+        num_words=10000,
+    )
+
+    logger.info('Title_onehot shape {}'.format(title_onehot.shape))
+
+    logger.info('One-hot encoding description sequences')
+
+    description_onehot = create_one_hot_matrix_for_column(
+        tokenizing.load_tokenizer_from_file(
+            os.path.join(DATADIR, "description_tokenizer.json")
+        ),
+        balanced_df.index.get_level_values('description'),
+        num_words=10000,
+    )
+
+    logger.info('Description_onehot shape')
+
+    logger.info('Train/dev/test splitting')
+
+    end_dev = size_train + size_dev
+
+    logger.info('end_dev ={}'.format(end_dev))
+    # assign the indices for separating the original (pre-sampled) data into
+    # train/dev/test
+    splits = [(0, size_train), (size_train, end_dev), (end_dev, balanced_df.shape[0])]
+    logger.info('splits ={}'.format(splits))
+
+    # convert columns to an array. Each row represents a content item,
+    # each column an individual taxon
+    binary_multilabel = balanced_df[list(balanced_df.columns)].values
+    logger.info('Shape of multilabel array {}'.format(binary_multilabel.shape))
+    logger.info('Example row of multilabel array {}'.format(binary_multilabel[2]))
+
+    data = {
+        "x": combined_text_sequences_padded,
+        "meta": meta,
+        "title": title_onehot,
+        "desc": description_onehot,
+        "y": sparse.csr_matrix(binary_multilabel),
+        "content_id": balanced_df.index.get_level_values('content_id'),
+    }
+
+    for split, name in zip(splits, ('branch_level_agnostic_train', 'branch_level_agnostic_dev', 'branch_level_agnostic_test')):
+        logger.info("Generating {} split".format(name))
+        process_split(
+            name,
+            split,
+            data
+        )
+
+    logger.info('Finished')

--- a/python/checking_dataprep_changes.ipynb
+++ b/python/checking_dataprep_changes.ipynb
@@ -1,0 +1,528 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "algorithm running on data extracted from content store on /data/2018-07-10\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "DATADIR = os.getenv('DATADIR')\n",
+    "print('algorithm running on data extracted from content store on {}'.format(DATADIR))\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Check level2 branch outputs are the same for old and new load_labelled()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "algorithm running on data extracted from content store on /data/2018-07-10\n",
+      "x_train.shape = (147742, 1000)\n",
+      "meta_train.shape = (147742, 511)\n",
+      "title_train.shape = (147742, 10000)\n",
+      "desc_train.shape = (147742, 10000)\n",
+      "y_train.shape = (147742, 210)\n",
+      "x_dev.shape = (8342, 1000)\n",
+      "meta_dev.shape = (8342, 511)\n",
+      "title_dev.shape = (8342, 10000)\n",
+      "desc_dev.shape = (8342, 10000)\n",
+      "y_dev.shape = (8342, 210)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#MASTER BRANCH\n",
+    "# ### Read in data\n",
+    "train = np.load(os.path.join(DATADIR, 'train_arrays.npz'))\n",
+    "\n",
+    "x_train = train['x']\n",
+    "meta_train = train['meta'].all().todense()\n",
+    "title_train = train['title'].all().todense()\n",
+    "desc_train = train['desc'].all().todense()\n",
+    "y_train = train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(x_train.shape))\n",
+    "print('meta_train.shape = {}'.format(meta_train.shape))\n",
+    "print('title_train.shape = {}'.format(title_train.shape))\n",
+    "print('desc_train.shape = {}'.format(desc_train.shape))\n",
+    "print('y_train.shape = {}'.format(y_train.shape))\n",
+    "\n",
+    "\n",
+    "dev = np.load(os.path.join(DATADIR, 'dev_arrays.npz'))\n",
+    "\n",
+    "x_dev = dev['x']\n",
+    "meta_dev = dev['meta'].all().todense()\n",
+    "title_dev = dev['title'].all().todense()\n",
+    "desc_dev = dev['desc'].all().todense()\n",
+    "y_dev = dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(meta_dev.shape))\n",
+    "print('title_dev.shape = {}'.format(title_dev.shape))\n",
+    "print('desc_dev.shape = {}'.format(desc_dev.shape))\n",
+    "print('y_dev.shape = {}'.format(y_dev.shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (147742, 1000)\n",
+      "meta_train.shape = (147742, 511)\n",
+      "title_train.shape = (147742, 10000)\n",
+      "desc_train.shape = (147742, 10000)\n",
+      "y_train.shape = (147742, 210)\n",
+      "x_dev.shape = (8342, 1000)\n",
+      "meta_dev.shape = (8342, 511)\n",
+      "title_dev.shape = (8342, 10000)\n",
+      "desc_dev.shape = (8342, 10000)\n",
+      "y_dev.shape = (8342, 210)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#ALL LEVELS BRANCH\n",
+    "\n",
+    "check_train = np.load(os.path.join(DATADIR, 'train_arrays.npz'))\n",
+    "\n",
+    "check_x_train = check_train['x']\n",
+    "check_meta_train = check_train['meta'].all().todense()\n",
+    "check_title_train = check_train['title'].all().todense()\n",
+    "check_desc_train = check_train['desc'].all().todense()\n",
+    "check_y_train = check_train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(check_x_train.shape))\n",
+    "print('meta_train.shape = {}'.format(check_meta_train.shape))\n",
+    "print('title_train.shape = {}'.format(check_title_train.shape))\n",
+    "print('desc_train.shape = {}'.format(check_desc_train.shape))\n",
+    "print('y_train.shape = {}'.format(check_y_train.shape))\n",
+    "\n",
+    "\n",
+    "check_dev = np.load(os.path.join(DATADIR, 'dev_arrays.npz'))\n",
+    "\n",
+    "check_x_dev = check_dev['x']\n",
+    "check_meta_dev = check_dev['meta'].all().todense()\n",
+    "check_title_dev = check_dev['title'].all().todense()\n",
+    "check_desc_dev = check_dev['desc'].all().todense()\n",
+    "check_y_dev = check_dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(check_x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(check_meta_dev.shape))\n",
+    "print('title_dev.shape = {}'.format(check_title_dev.shape))\n",
+    "print('desc_dev.shape = {}'.format(check_desc_dev.shape))\n",
+    "print('y_dev.shape = {}'.format(check_y_dev.shape))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(np.array_equiv(x_train, check_x_train))\n",
+    "print(np.array_equiv(x_dev, check_x_dev))\n",
+    "print(np.array_equiv(meta_train, check_meta_train))\n",
+    "print(np.array_equiv(title_train, check_title_train))\n",
+    "print(np.array_equiv(desc_train, check_desc_train))\n",
+    "print(np.array_equiv(y_train, check_y_train))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Check level1 branch outputs are the same for old and new load_labelled()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (71064, 1000)\n",
+      "meta_train.shape = (71064, 511)\n",
+      "title_train.shape = (71064, 10000)\n",
+      "desc_train.shape = (71064, 10000)\n",
+      "y_train.shape = (71064, 20)\n",
+      "x_dev.shape = (8695, 1000)\n",
+      "meta_dev.shape = (8695, 511)\n",
+      "title_dev.shape = (8695, 10000)\n",
+      "desc_dev.shape = (8695, 10000)\n",
+      "y_dev.shape = (8695, 20)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#MASTER BRANCH\n",
+    "# ### Read in data\n",
+    "train = np.load(os.path.join(DATADIR, 'level1_train_arrays.npz'))\n",
+    "\n",
+    "x_train = train['x']\n",
+    "meta_train = train['meta'].all().todense()\n",
+    "title_train = train['title'].all().todense()\n",
+    "desc_train = train['desc'].all().todense()\n",
+    "y_train = train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(x_train.shape))\n",
+    "print('meta_train.shape = {}'.format(meta_train.shape))\n",
+    "print('title_train.shape = {}'.format(title_train.shape))\n",
+    "print('desc_train.shape = {}'.format(desc_train.shape))\n",
+    "print('y_train.shape = {}'.format(y_train.shape))\n",
+    "\n",
+    "\n",
+    "dev = np.load(os.path.join(DATADIR, 'level1_dev_arrays.npz'))\n",
+    "\n",
+    "x_dev = dev['x']\n",
+    "meta_dev = dev['meta'].all().todense()\n",
+    "title_dev = dev['title'].all().todense()\n",
+    "desc_dev = dev['desc'].all().todense()\n",
+    "y_dev = dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(meta_dev.shape))\n",
+    "print('title_dev.shape = {}'.format(title_dev.shape))\n",
+    "print('desc_dev.shape = {}'.format(desc_dev.shape))\n",
+    "print('y_dev.shape = {}'.format(y_dev.shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (71064, 1000)\n",
+      "meta_train.shape = (71064, 511)\n",
+      "title_train.shape = (71064, 10000)\n",
+      "desc_train.shape = (71064, 10000)\n",
+      "y_train.shape = (71064, 20)\n",
+      "x_dev.shape = (8695, 1000)\n",
+      "meta_dev.shape = (8695, 511)\n",
+      "title_dev.shape = (8695, 10000)\n",
+      "desc_dev.shape = (8695, 10000)\n",
+      "y_dev.shape = (8695, 20)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#ALL LEVELS BRANCH\n",
+    "\n",
+    "check_train = np.load(os.path.join(DATADIR, 'level1_train_arrays.npz'))\n",
+    "\n",
+    "check_x_train = check_train['x']\n",
+    "check_meta_train = check_train['meta'].all().todense()\n",
+    "check_title_train = check_train['title'].all().todense()\n",
+    "check_desc_train = check_train['desc'].all().todense()\n",
+    "check_y_train = check_train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(check_x_train.shape))\n",
+    "print('meta_train.shape = {}'.format(check_meta_train.shape))\n",
+    "print('title_train.shape = {}'.format(check_title_train.shape))\n",
+    "print('desc_train.shape = {}'.format(check_desc_train.shape))\n",
+    "print('y_train.shape = {}'.format(check_y_train.shape))\n",
+    "\n",
+    "\n",
+    "check_dev = np.load(os.path.join(DATADIR, 'level1_dev_arrays.npz'))\n",
+    "\n",
+    "check_x_dev = check_dev['x']\n",
+    "check_meta_dev = check_dev['meta'].all().todense()\n",
+    "check_title_dev = check_dev['title'].all().todense()\n",
+    "check_desc_dev = check_dev['desc'].all().todense()\n",
+    "check_y_dev = check_dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(check_x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(check_meta_dev.shape))\n",
+    "print('title_dev.shape = {}'.format(check_title_dev.shape))\n",
+    "print('desc_dev.shape = {}'.format(check_desc_dev.shape))\n",
+    "print('y_dev.shape = {}'.format(check_y_dev.shape))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.array_equiv(x_train, check_x_train))\n",
+    "print(np.array_equiv(x_dev, check_x_dev))\n",
+    "print(np.array_equiv(meta_train, check_meta_train))\n",
+    "print(np.array_equiv(title_train, check_title_train))\n",
+    "print(np.array_equiv(desc_train, check_desc_train))\n",
+    "print(np.array_equiv(y_train, check_y_train))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Check level agnostic -at level not deeper outputs are the same for old and new load_labelled()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (149658, 1000)\n",
+      "meta_train.all().shape = (149658, 511)\n",
+      "title_train.all().shape = (149658, 10000)\n",
+      "desc_train.all().shape = (149658, 10000)\n",
+      "y_train.shape = (149658, 1587)\n",
+      "x_dev.shape = (18707, 1000)\n",
+      "meta_dev.shape = (18707, 511)\n",
+      "title_dev.shape = (18707, 10000)\n",
+      "desc_dev.shape = (18707, 10000)\n",
+      "y_dev.shape = (18707, 1587)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# previous results with upsampling of 500 if taxon <500\n",
+    "\n",
+    "train = np.load(os.path.join(DATADIR, 'level_agnostic_train_arrays.npz'))\n",
+    "\n",
+    "x_train = train['x']\n",
+    "meta_train = train['meta']\n",
+    "title_train = train['title']\n",
+    "desc_train = train['desc']\n",
+    "y_train = train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(x_train.shape))\n",
+    "print('meta_train.all().shape = {}'.format(meta_train.all().shape))\n",
+    "print('title_train.all().shape = {}'.format(title_train.all().shape))\n",
+    "print('desc_train.all().shape = {}'.format(desc_train.all().shape))\n",
+    "print('y_train.shape = {}'.format(y_train.shape))\n",
+    "\n",
+    "\n",
+    "dev = np.load(os.path.join(DATADIR, 'level_agnostic_dev_arrays.npz'))\n",
+    "\n",
+    "x_dev = dev['x']\n",
+    "meta_dev = dev['meta']\n",
+    "title_dev = dev['title']\n",
+    "desc_dev = dev['desc']\n",
+    "y_dev = dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(meta_dev.all().shape))\n",
+    "print('title_dev.shape = {}'.format(title_dev.all().shape))\n",
+    "print('desc_dev.shape = {}'.format(desc_dev.all().shape))\n",
+    "print('y_dev.shape = {}'.format(y_dev.shape))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (130864, 1000)\n",
+      "meta_train.all().shape = (130864, 511)\n",
+      "title_train.all().shape = (130864, 10000)\n",
+      "desc_train.all().shape = (130864, 10000)\n",
+      "y_train.shape = (130864, 1269)\n",
+      "x_dev.shape = (8695, 1000)\n",
+      "meta_dev.shape = (8695, 511)\n",
+      "title_dev.shape = (8695, 10000)\n",
+      "desc_dev.shape = (8695, 10000)\n",
+      "y_dev.shape = (8695, 1269)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# all-levels branch\n",
+    "\n",
+    "train = np.load(os.path.join(DATADIR, 'level_agnostic_train_arrays.npz'))\n",
+    "\n",
+    "x_train = train['x']\n",
+    "meta_train = train['meta']\n",
+    "title_train = train['title']\n",
+    "desc_train = train['desc']\n",
+    "y_train = train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(x_train.shape))\n",
+    "print('meta_train.all().shape = {}'.format(meta_train.all().shape))\n",
+    "print('title_train.all().shape = {}'.format(title_train.all().shape))\n",
+    "print('desc_train.all().shape = {}'.format(desc_train.all().shape))\n",
+    "print('y_train.shape = {}'.format(y_train.shape))\n",
+    "\n",
+    "\n",
+    "dev = np.load(os.path.join(DATADIR, 'level_agnostic_dev_arrays.npz'))\n",
+    "\n",
+    "x_dev = dev['x']\n",
+    "meta_dev = dev['meta']\n",
+    "title_dev = dev['title']\n",
+    "desc_dev = dev['desc']\n",
+    "y_dev = dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(meta_dev.all().shape))\n",
+    "print('title_dev.shape = {}'.format(title_dev.all().shape))\n",
+    "print('desc_dev.shape = {}'.format(desc_dev.all().shape))\n",
+    "print('y_dev.shape = {}'.format(y_dev.shape))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## These are different because the memory requirements to upsample 500 for each of the taxons with <500 items was to great for the tokenizer.sequences_to_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_train.shape = (126764, 1000)\n",
+      "meta_train.all().shape = (126764, 511)\n",
+      "title_train.all().shape = (126764, 10000)\n",
+      "desc_train.all().shape = (126764, 10000)\n",
+      "y_train.shape = (126764, 1219)\n",
+      "x_dev.shape = (8695, 1000)\n",
+      "meta_dev.shape = (8695, 511)\n",
+      "title_dev.shape = (8695, 10000)\n",
+      "desc_dev.shape = (8695, 10000)\n",
+      "y_dev.shape = (8695, 1219)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# all-levels branch \n",
+    "\n",
+    "train = np.load(os.path.join(DATADIR, 'branch_level_agnostic_train_arrays.npz'))\n",
+    "\n",
+    "x_train = train['x']\n",
+    "meta_train = train['meta']\n",
+    "title_train = train['title']\n",
+    "desc_train = train['desc']\n",
+    "y_train = train['y'].all().todense()\n",
+    "\n",
+    "print('x_train.shape = {}'.format(x_train.shape))\n",
+    "print('meta_train.all().shape = {}'.format(meta_train.all().shape))\n",
+    "print('title_train.all().shape = {}'.format(title_train.all().shape))\n",
+    "print('desc_train.all().shape = {}'.format(desc_train.all().shape))\n",
+    "print('y_train.shape = {}'.format(y_train.shape))\n",
+    "\n",
+    "\n",
+    "dev = np.load(os.path.join(DATADIR, 'branch_level_agnostic_dev_arrays.npz'))\n",
+    "\n",
+    "x_dev = dev['x']\n",
+    "meta_dev = dev['meta']\n",
+    "title_dev = dev['title']\n",
+    "desc_dev = dev['desc']\n",
+    "y_dev = dev['y'].all().todense()\n",
+    "\n",
+    "print('x_dev.shape = {}'.format(x_dev.shape))\n",
+    "print('meta_dev.shape = {}'.format(meta_dev.all().shape))\n",
+    "print('title_dev.shape = {}'.format(title_dev.all().shape))\n",
+    "print('desc_dev.shape = {}'.format(desc_dev.all().shape))\n",
+    "print('y_dev.shape = {}'.format(y_dev.shape))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "somthing suspicious. The branch taxons shouldn't have less than th at_level taxons. Why is this happening????"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/dataprep.py
+++ b/python/dataprep.py
@@ -127,11 +127,9 @@ def save_taxon_label_index(dataframe, level='level2', branch=True):
         with open(os.path.join(DATADIR, level+"taxon_id_index.json"),'w') as f:
             json.dump(taxonid_index, f)
 
-
     with open(os.path.join(DATADIR, level+"taxon_labels_index.json"),'w') as f:
         json.dump(labels_index, f)
 
-   
 
 
 def create_binary_multilabel(dataframe):

--- a/python/dataprep.py
+++ b/python/dataprep.py
@@ -85,6 +85,8 @@ def load_labelled(SINCE_THRESHOLD, level='level2', branch=True):
             df = labelled.loc[labelled['level']==4].copy()
         elif level=='level5':
             df = labelled.loc[labelled['level']==5].copy()
+        else:
+            df = labelled.copy()
 
     create_taxon_codes(df, branch=branch, level=level)
     save_taxon_label_index(df, branch=branch, level=level)
@@ -167,7 +169,7 @@ def create_binary_multilabel(dataframe):
     return binary_multi
 
 
-def upsample_low_support_taxons(dataframe, size_train):
+def upsample_low_support_taxons(dataframe, size_train, n_samples=500):
     # extract indices of training samples, which are to be upsampled
 
     training_indices = [dataframe.index[i][0] for i in range(0, size_train)]
@@ -179,7 +181,6 @@ def upsample_low_support_taxons(dataframe, size_train):
         training_samples_tagged_to_taxon = dataframe[
                                                dataframe[taxon] == 1
                                                ][:size_train]
-
         if training_samples_tagged_to_taxon.shape[0] < 500:
             logging.info("Taxon code: %s", taxon)
             logging.info("SMALL SUPPORT: %s", training_samples_tagged_to_taxon.shape[0])
@@ -189,7 +190,7 @@ def upsample_low_support_taxons(dataframe, size_train):
                 logging.info(df_minority.shape)
                 df_minority_upsampled = resample(df_minority,
                                                  replace=True,  # sample with replacement
-                                                 n_samples=(500),
+                                                 n_samples=(n_samples),
                                                  # to match majority class, switch to max_content_freq if works
                                                  random_state=123)  # reproducible results
                 # logging.info("FIRST 5 IDs: %s", [df_minority_upsampled.index[i][0] for i in range(0, 5)])

--- a/python/dataprep.py
+++ b/python/dataprep.py
@@ -70,7 +70,7 @@ def load_labelled(SINCE_THRESHOLD, level='level2', branch=True):
             df[df.branch_level==level+'taxon'].drop_duplicates(subset=['content_id', 'branch_name'],
                                                                                    inplace=True)
         else:                   # should only be 'agnostic'
-            df.drop_duplicates(subset=['content_id', 'level_branch_name'], inplace=true)
+            df = branches.drop_duplicates(subset=['content_id', 'level_branch_name']).copy()
             # creating categorical variable for level2taxons from values
     
         

--- a/python/level1_dataprep.py
+++ b/python/level1_dataprep.py
@@ -34,10 +34,10 @@ if __name__ == "__main__":
     logger = logging.getLogger('level1_dataprep')
 
     logger.info('Loading data')
-    labelled_level1 = load_labelled(SINCE_THRESHOLD, level='level1')
+    labelled_level1 = load_labelled(SINCE_THRESHOLD, level='level1', branch=True)
 
     logger.info('Creating multilabel dataframe')
-    binary_multilabel = create_binary_multilabel(labelled_level1, taxon_code_column='level1taxon_code')
+    binary_multilabel = create_binary_multilabel(labelled_level1)
     print(binary_multilabel.columns)
 
     np.save(os.path.join(DATADIR, 'level1_taxon_codes.npy'), binary_multilabel.columns)

--- a/python/level_agnostic_dataprep.py
+++ b/python/level_agnostic_dataprep.py
@@ -26,10 +26,10 @@ if __name__ == "__main__":
     logger = logging.getLogger('levelagnostic_dataprep')
 
     logger.info('Loading data')
-    labelled = load_labelled(SINCE_THRESHOLD, level='agnostic')
+    labelled = load_labelled(SINCE_THRESHOLD, level='agnostic', branch=False)
 
     logger.info('Creating multilabel dataframe')
-    binary_multilabel = create_binary_multilabel(labelled, taxon_code_column='taxon_code')
+    binary_multilabel = create_binary_multilabel(labelled)
    
     print(binary_multilabel.columns)
 
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     logger.info('Upsample low support taxons')
 
-    balanced_df, upsample_size = upsample_low_support_taxons(binary_multilabel, size_train)
+    balanced_df, upsample_size = upsample_low_support_taxons(binary_multilabel, size_train, n_samples=50)
 
     logger.info("Shape of balanced_df: {}".format(balanced_df.shape))
     


### PR DESCRIPTION
Do not merge until remedied.
This branch changes the way that dataprep.py creates the labelled examples. Now examples can be specified to be at any level ('level1' etc and 'agnostic') and also whether to include all items in the branch for that level (branch=True) or just the items tagged AT that level. 

However, the accompanying notebook demonstrates that the branch_level_agnostic.py script produces y vectors which are shorter than the y vectors produced by the exact/at examples(obtained using the level_agnostic.py script). This should be the other way around (because the recursive taxon-branches should contain more content that just the taxon_ids). This needs to be remedied before merging this PR.

In addition, the commits here will need squashing.